### PR TITLE
Audio fade in toggle

### DIFF
--- a/binding/audio-binding.cpp
+++ b/binding/audio-binding.cpp
@@ -97,8 +97,8 @@ RB_METHOD_GUARD(audio_bgmPlay)
     int pitch = 100;
     double pos = 0.0;
     VALUE track = Qnil;
-	bool fadeIn = true;
-    rb_get_args(argc, argv, "z|iifob", &filename, &volume, &pitch, &pos, &track, &fadeIn RB_ARG_END);
+	VALUE fadeInArg = Qnil;
+    rb_get_args(argc, argv, "z|iifoo", &filename, &volume, &pitch, &pos, &track, &fadeInArg RB_ARG_END);
     shState->audio().bgmPlay(filename, volume, pitch, pos, MAYBE_NIL_TRACK(track), fadeIn);
     return Qnil;
 }

--- a/binding/audio-binding.cpp
+++ b/binding/audio-binding.cpp
@@ -98,7 +98,7 @@ RB_METHOD_GUARD(audio_bgmPlay)
     double pos = 0.0;
     VALUE track = Qnil;
 	int fadeIn = -1;
-    rb_get_args(argc, argv, "z|iifoi", &filename, &volume, &pitch, &pos, &track, &fadeInArg RB_ARG_END);
+    rb_get_args(argc, argv, "z|iifoi", &filename, &volume, &pitch, &pos, &track, &fadeIn RB_ARG_END);
     shState->audio().bgmPlay(filename, volume, pitch, pos, MAYBE_NIL_TRACK(track), fadeIn);
     return Qnil;
 }

--- a/binding/audio-binding.cpp
+++ b/binding/audio-binding.cpp
@@ -96,8 +96,9 @@ RB_METHOD_GUARD(audio_bgmPlay)
     int volume = 100;
     int pitch = 100;
     double pos = 0.0;
+	bool fadeIn = true;
     VALUE track = Qnil;
-    rb_get_args(argc, argv, "z|iifo", &filename, &volume, &pitch, &pos, &track RB_ARG_END);
+    rb_get_args(argc, argv, "z|iifo", &filename, &volume, &pitch, &pos, &fadeIn, &track RB_ARG_END);
     shState->audio().bgmPlay(filename, volume, pitch, pos, MAYBE_NIL_TRACK(track));
     return Qnil;
 }

--- a/binding/audio-binding.cpp
+++ b/binding/audio-binding.cpp
@@ -98,7 +98,7 @@ RB_METHOD_GUARD(audio_bgmPlay)
     double pos = 0.0;
     VALUE track = Qnil;
 	bool fadeIn = true;
-    rb_get_args(argc, argv, "z|iifo", &filename, &volume, &pitch, &pos, &track, &fadeIn RB_ARG_END);
+    rb_get_args(argc, argv, "z|iifob", &filename, &volume, &pitch, &pos, &track, &fadeIn RB_ARG_END);
     shState->audio().bgmPlay(filename, volume, pitch, pos, MAYBE_NIL_TRACK(track), fadeIn);
     return Qnil;
 }

--- a/binding/audio-binding.cpp
+++ b/binding/audio-binding.cpp
@@ -96,10 +96,10 @@ RB_METHOD_GUARD(audio_bgmPlay)
     int volume = 100;
     int pitch = 100;
     double pos = 0.0;
-	bool fadeIn = true;
     VALUE track = Qnil;
-    rb_get_args(argc, argv, "z|iifo", &filename, &volume, &pitch, &pos, &fadeIn, &track RB_ARG_END);
-    shState->audio().bgmPlay(filename, volume, pitch, pos, MAYBE_NIL_TRACK(track));
+	bool fadeIn = true;
+    rb_get_args(argc, argv, "z|iifo", &filename, &volume, &pitch, &pos, &track, &fadeIn RB_ARG_END);
+    shState->audio().bgmPlay(filename, volume, pitch, pos, MAYBE_NIL_TRACK(track), fadeIn);
     return Qnil;
 }
 RB_METHOD_GUARD_END

--- a/binding/audio-binding.cpp
+++ b/binding/audio-binding.cpp
@@ -97,8 +97,8 @@ RB_METHOD_GUARD(audio_bgmPlay)
     int pitch = 100;
     double pos = 0.0;
     VALUE track = Qnil;
-	VALUE fadeInArg = Qnil;
-    rb_get_args(argc, argv, "z|iifoo", &filename, &volume, &pitch, &pos, &track, &fadeInArg RB_ARG_END);
+	int fadeIn = -1;
+    rb_get_args(argc, argv, "z|iifoi", &filename, &volume, &pitch, &pos, &track, &fadeInArg RB_ARG_END);
     shState->audio().bgmPlay(filename, volume, pitch, pos, MAYBE_NIL_TRACK(track), fadeIn);
     return Qnil;
 }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -293,6 +293,7 @@ void Audio::bgmPlay(const char *filename,
                     int volume,
                     int pitch,
                     double pos,
+                    bool fadeIn,
                     int track)
 {
     if (track == -127) {
@@ -305,7 +306,7 @@ void Audio::bgmPlay(const char *filename,
         
         track = 0;
     }
-	p->getTrackByIndex(track)->play(filename, volume, pitch, pos);
+	p->getTrackByIndex(track)->play(filename, volume, pitch, pos, fadeIn);
 }
 
 void Audio::bgmStop(int track)

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -294,7 +294,7 @@ void Audio::bgmPlay(const char *filename,
                     int pitch,
                     double pos,
                     int track,
-                    VALUE fadeIn)
+                    int fadeIn)
 {
     if (track == -127) {
         for (int i = 0; i < (int)p->bgmTracks.size(); i++) {

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -293,8 +293,8 @@ void Audio::bgmPlay(const char *filename,
                     int volume,
                     int pitch,
                     double pos,
-                    bool fadeIn,
-                    int track)
+                    int track,
+                    bool fadeIn)
 {
     if (track == -127) {
         for (int i = 0; i < (int)p->bgmTracks.size(); i++) {

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -294,7 +294,7 @@ void Audio::bgmPlay(const char *filename,
                     int pitch,
                     double pos,
                     int track,
-                    bool fadeIn)
+                    VALUE fadeIn)
 {
     if (track == -127) {
         for (int i = 0; i < (int)p->bgmTracks.size(); i++) {

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -43,7 +43,7 @@ public:
 	             int pitch = 100,
 	             double pos = 0,
                  int track = -127,
-				 VALUE fadeIn = Qnil);
+				 int fadeIn = -1);
 	void bgmStop(int track = -127);
 	void bgmFade(int time, int track = -127);
     int bgmGetVolume(int track = -127);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -42,6 +42,7 @@ public:
 	             int volume = 100,
 	             int pitch = 100,
 	             double pos = 0,
+				 bool fadeIn = true,
                  int track = -127);
 	void bgmStop(int track = -127);
 	void bgmFade(int time, int track = -127);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -43,7 +43,7 @@ public:
 	             int pitch = 100,
 	             double pos = 0,
                  int track = -127,
-				 bool fadeIn = true);
+				 VALUE fadeIn = true);
 	void bgmStop(int track = -127);
 	void bgmFade(int time, int track = -127);
     int bgmGetVolume(int track = -127);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -42,8 +42,8 @@ public:
 	             int volume = 100,
 	             int pitch = 100,
 	             double pos = 0,
-				 bool fadeIn = true,
-                 int track = -127);
+                 int track = -127,
+				 bool fadeIn = true);
 	void bgmStop(int track = -127);
 	void bgmFade(int time, int track = -127);
     int bgmGetVolume(int track = -127);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -43,7 +43,7 @@ public:
 	             int pitch = 100,
 	             double pos = 0,
                  int track = -127,
-				 VALUE fadeIn = true);
+				 VALUE fadeIn = Qnil);
 	void bgmStop(int track = -127);
 	void bgmFade(int time, int track = -127);
     int bgmGetVolume(int track = -127);

--- a/src/audio/audiostream.cpp
+++ b/src/audio/audiostream.cpp
@@ -77,7 +77,7 @@ void AudioStream::play(const std::string &filename,
                        int volume,
                        int pitch,
                        double offset,
-					   VALUE fadeIn)
+					   int fadeIn)
 {
 	finiFadeOutInt();
 
@@ -141,11 +141,11 @@ void AudioStream::play(const std::string &filename,
 
 	switch (fadeIn)
 	{
-		case true:
+		case 1:
 			setVolume(FadeIn, 0);
 			startFadeIn();
 			break;
-		case false:
+		case 0:
 			break;
 		default:
 			if (offset > 0)

--- a/src/audio/audiostream.cpp
+++ b/src/audio/audiostream.cpp
@@ -77,7 +77,7 @@ void AudioStream::play(const std::string &filename,
                        int volume,
                        int pitch,
                        double offset,
-					   int fadeIn)
+                       int fadeIn)
 {
 	finiFadeOutInt();
 

--- a/src/audio/audiostream.cpp
+++ b/src/audio/audiostream.cpp
@@ -77,7 +77,7 @@ void AudioStream::play(const std::string &filename,
                        int volume,
                        int pitch,
                        double offset,
-					   bool fadeIn)
+					   VALUE fadeIn)
 {
 	finiFadeOutInt();
 
@@ -139,10 +139,20 @@ void AudioStream::play(const std::string &filename,
 	setVolume(Base, _volume);
 	stream.setPitch(_pitch);
 
-	if (offset > 0 && fadeIn)
+	switch (fadeIn)
 	{
-		setVolume(FadeIn, 0);
-		startFadeIn();
+		case true:
+			setVolume(FadeIn, 0);
+			startFadeIn();
+			break;
+		case false:
+			break;
+		default:
+			if (offset > 0)
+			{
+				setVolume(FadeIn, 0);
+				startFadeIn();
+			}
 	}
 
 	current.filename = filename;

--- a/src/audio/audiostream.cpp
+++ b/src/audio/audiostream.cpp
@@ -76,7 +76,8 @@ AudioStream::~AudioStream()
 void AudioStream::play(const std::string &filename,
                        int volume,
                        int pitch,
-                       double offset)
+                       double offset,
+					   bool fadeIn)
 {
 	finiFadeOutInt();
 
@@ -138,7 +139,7 @@ void AudioStream::play(const std::string &filename,
 	setVolume(Base, _volume);
 	stream.setPitch(_pitch);
 
-	if (offset > 0)
+	if (offset > 0 && fadeIn)
 	{
 		setVolume(FadeIn, 0);
 		startFadeIn();

--- a/src/audio/audiostream.h
+++ b/src/audio/audiostream.h
@@ -127,7 +127,8 @@ struct AudioStream
 	void play(const std::string &filename,
 	          int volume,
 	          int pitch,
-	          double offset = 0);
+	          double offset = 0,
+			  bool fadeIn = true);
 	void stop();
 	void fadeOut(int duration);
 	void seek(double offset);

--- a/src/audio/audiostream.h
+++ b/src/audio/audiostream.h
@@ -128,7 +128,7 @@ struct AudioStream
 	          int volume,
 	          int pitch,
 	          double offset = 0,
-			  bool fadeIn = true);
+			  VALUE fadeIn = true);
 	void stop();
 	void fadeOut(int duration);
 	void seek(double offset);

--- a/src/audio/audiostream.h
+++ b/src/audio/audiostream.h
@@ -128,7 +128,7 @@ struct AudioStream
 	          int volume,
 	          int pitch,
 	          double offset = 0,
-			  VALUE fadeIn = Qnil);
+			  int fadeIn = -1);
 	void stop();
 	void fadeOut(int duration);
 	void seek(double offset);

--- a/src/audio/audiostream.h
+++ b/src/audio/audiostream.h
@@ -128,7 +128,7 @@ struct AudioStream
 	          int volume,
 	          int pitch,
 	          double offset = 0,
-			  VALUE fadeIn = true);
+			  VALUE fadeIn = Qnil);
 	void stop();
 	void fadeOut(int duration);
 	void seek(double offset);


### PR DESCRIPTION
Change `startFadeIn()` handling in `AudioStream::play` to account for multiple options:
- `1` - Always fade in music
- `0` - Do not fade in music
- Anything else (`-1` by default) - Default handling.